### PR TITLE
Retrieve the 'buttons' parameter from the song info and use it to determ...

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
@@ -751,8 +751,15 @@ public class NowPlayingFragment extends Fragment implements
             if (mFullHeightLayout) {
                 artistText.setText(song.getArtist());
                 if (song.isRemote()) {
-                    nextButton.setEnabled(false);
-                    Util.setAlpha(nextButton, 0.25f);
+                    if (song.getButtons().length() == 0) {
+                        nextButton.setEnabled(false);
+                        Util.setAlpha(nextButton, 0.25f);
+                    } else {
+                        // TODO: figure out how to parse the buttons HASH;
+                        // for now just assume the next button is enabled
+                        nextButton.setEnabled(true);
+                        Util.setAlpha(nextButton, 1.0f);
+                    }
                     prevButton.setEnabled(false);
                     Util.setAlpha(prevButton, 0.25f);
                     btnContextMenu.setVisibility(View.GONE);

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Song.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Song.java
@@ -122,6 +122,13 @@ public class Song extends ArtworkItem {
         return mUrl;
     }
 
+    @NonNull private final String mButtons;
+
+    @NonNull
+    public String getButtons() {
+        return mButtons;
+    }
+
     @NonNull private String mArtworkUrl;
 
     /**
@@ -173,6 +180,7 @@ public class Song extends ArtworkItem {
         mTrackNum = Util.parseDecimalInt(record.get("tracknum"), 1);
         mArtworkUrl = Strings.nullToEmpty(record.get("artwork_url"));
         mUrl = Strings.nullToEmpty(record.get("url"));
+        mButtons = Strings.nullToEmpty(record.get("buttons"));
 
         // Work around a (possible) bug in the Squeezeserver.
         //
@@ -222,6 +230,7 @@ public class Song extends ArtworkItem {
         setArtwork_track_id(source.readString());
         mTrackNum = source.readInt();
         mUrl = source.readString();
+        mButtons = source.readString();
     }
 
     public void writeToParcel(Parcel dest, int flags) {
@@ -237,6 +246,7 @@ public class Song extends ArtworkItem {
         dest.writeString(getArtwork_track_id());
         dest.writeInt(mTrackNum);
         dest.writeString(mUrl);
+        dest.writeString(mButtons);
     }
 
     @Override


### PR DESCRIPTION
...ine what buttons to show when the song is remote.  Note the only documentation on the 'buttons' parameter is "A hash with button definitions"; it isn't clear how this can be mapped to buttons.  For now we just assume that the presence of a button hash means 'next' is supported.  This allows the user to skip the current song when using the Slacker app.