### PR TITLE
Changed order of Scrobblers

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/util/Scrobble.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/util/Scrobble.java
@@ -48,16 +48,7 @@ public class Scrobble {
         Log.d("Scrobble", "Scrobbling, playing is: " + (PlayerState.PLAY_STATE_PLAY.equals(playStatus)));
         Intent i = new Intent();
 
-        if (Scrobble.haveScrobbleDroid()) {
-            // http://code.google.com/p/scrobbledroid/wiki/DeveloperAPI
-            i.setAction("net.jjc1138.android.scrobbler.action.MUSIC_STATUS");
-            i.putExtra("playing", PlayerState.PLAY_STATE_PLAY.equals(playStatus));
-            i.putExtra("track", currentSong.getName());
-            i.putExtra("album", currentSong.getAlbum());
-            i.putExtra("artist", currentSong.getArtist());
-            i.putExtra("secs", currentSong.getDuration());
-            i.putExtra("source", "P");
-        } else if (Scrobble.haveSls()) {
+        if (Scrobble.haveSls()) {
             // http://code.google.com/p/a-simple-lastfm-scrobbler/wiki/Developers
             i.setAction("com.adam.aslfms.notify.playstatechanged");
             i.putExtra("state", PlayerState.PLAY_STATE_PLAY.equals(playStatus) ? 0 : 2);
@@ -67,6 +58,15 @@ public class Scrobble {
             i.putExtra("album", currentSong.getAlbum());
             i.putExtra("artist", currentSong.getArtist());
             i.putExtra("duration", currentSong.getDuration());
+            i.putExtra("source", "P");
+        } else if (Scrobble.haveScrobbleDroid()) {
+            // http://code.google.com/p/scrobbledroid/wiki/DeveloperAPI
+            i.setAction("net.jjc1138.android.scrobbler.action.MUSIC_STATUS");
+            i.putExtra("playing", PlayerState.PLAY_STATE_PLAY.equals(playStatus));
+            i.putExtra("track", currentSong.getName());
+            i.putExtra("album", currentSong.getAlbum());
+            i.putExtra("artist", currentSong.getArtist());
+            i.putExtra("secs", currentSong.getDuration());
             i.putExtra("source", "P");
         }
         context.sendBroadcast(i);


### PR DESCRIPTION
For better compatibility with SLS.
Squeezer will now default to SLS when both ScrobbleDroid and SLS receivers are present.

SLS is receiving ScrobbleDroid intents when it should be receiving SLS intents.
I don't have a working Logitech Media Server. (it's not streaming music to Squeezer, only download/browsing)
This should solve the bug that I can't test for in SLS.

This should make a percentage of Squeezer users very happy.