### PR TITLE
Current playlist: add menu option to select current song

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/CurrentPlaylistActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/CurrentPlaylistActivity.java
@@ -208,7 +208,9 @@ public class CurrentPlaylistActivity extends BaseListActivity<Song> {
      */
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
-        final int[] ids = {R.id.menu_item_playlist_clear, R.id.menu_item_playlist_save};
+        final int[] ids = {R.id.menu_item_playlist_clear, R.id.menu_item_playlist_save,
+                R.id.menu_item_playlist_show_current_song};
+
         final boolean knowCurrentPlaylist = getCurrentPlaylist() != null;
 
         for (int id : ids) {
@@ -231,6 +233,10 @@ public class CurrentPlaylistActivity extends BaseListActivity<Song> {
             case R.id.menu_item_playlist_save:
                 PlaylistSaveDialog.addTo(this, getCurrentPlaylist());
                 return true;
+            case R.id.menu_item_playlist_show_current_song:
+                selectCurrentSong(currentPlaylistIndex, 0);
+                return true;
+
         }
         return super.onOptionsItemSelected(item);
     }

--- a/Squeezer/src/main/res/menu/currentplaylistmenu.xml
+++ b/Squeezer/src/main/res/menu/currentplaylistmenu.xml
@@ -31,4 +31,10 @@
         android:icon="@drawable/ic_action_playlist_save"
         app:showAsAction="ifRoom|withText"
         android:orderInCategory="0"/>
+    <item
+        android:id="@+id/menu_item_playlist_show_current_song"
+        android:title="@string/menu_item_playlist_show_current_song"
+        app:showAsAction="never"
+        android:orderInCategory="0"/>
+
 </menu>

--- a/Squeezer/src/main/res/values-de/strings.xml
+++ b/Squeezer/src/main/res/values-de/strings.xml
@@ -68,6 +68,7 @@
     <string name="menu_item_playlists_new">Neu</string>
     <string name="menu_item_playlist_clear">Löschen</string>
     <string name="menu_item_playlist_save">Speichern</string>
+    <string name="menu_item_playlist_show_current_song">Aktuelles Lied</string>
     <string name="menu_item_volume">Lautstärke</string>
     <string name="connecting_text">Verbinde</string>
     <string name="connecting_to_text">Verbinde mit SqueezeBox CLI %s</string>

--- a/Squeezer/src/main/res/values/strings.xml
+++ b/Squeezer/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="menu_item_playlists_new">New</string>
     <string name="menu_item_playlist_clear">Clear playlist</string>
     <string name="menu_item_playlist_save">Save as playlist</string>
+    <string name="menu_item_playlist_show_current_song">Current song</string>
     <string name="menu_item_volume">Change volume</string>
     <string name="connecting_text">Connecting</string>
     <string name="connect_to_text">Connect to %s</string>


### PR DESCRIPTION
Useful when having scrolled through a huge playlist to find back to the current title