### PR TITLE
Players now sorted by playername in drop down list and player setting page.

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
@@ -468,6 +468,7 @@ public class NowPlayingFragment extends Fragment implements View.OnCreateContext
                 connectedPlayers.add(player);
             }
         }
+        Collections.sort(connectedPlayers); // sort players alphabetically by player name
 
         ActionBar actionBar = mActivity.getSupportActionBar();
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/PlayerListAdapter.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/PlayerListAdapter.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import uk.org.ngo.squeezer.R;
 import uk.org.ngo.squeezer.framework.ItemAdapter;
@@ -93,17 +94,20 @@ class PlayerListAdapter extends BaseExpandableListAdapter implements View.OnCrea
         prevPlayerSyncGroups = HashMultimap.create(playerSyncGroups);
         clear();
 
-        List<String> masters = new ArrayList<String>(playerSyncGroups.keySet());
-        Collections.sort(masters);
+        ArrayList<Player> masters = new ArrayList<Player>(playerSyncGroups.values());
+        Collections.sort(masters); // sort player list alphabetically by player name
 
-        for (String masterId : masters) {
-            ItemAdapter<Player> childAdapter = new ItemAdapter<Player>(new PlayerView(mActivity));
+        for (Player master : masters) {
+            String masterId = master.getId();
+            if (playerSyncGroups.containsKey(masterId)) { // masterId doesn't have to be present in the playerSyncGroups key list
+                ItemAdapter<Player> childAdapter = new ItemAdapter<Player>(new PlayerView(mActivity));
 
-            List<Player> slaves = new ArrayList<Player>(playerSyncGroups.get(masterId));
-            mPlayerCount += slaves.size();
-            Collections.sort(slaves, Player.compareById);
-            childAdapter.update(slaves.size(), 0, slaves);
-            mChildAdapters.add(childAdapter);
+                List<Player> slaves = new ArrayList<Player>(playerSyncGroups.get(masterId));
+                mPlayerCount += slaves.size();
+                Collections.sort(slaves); // order slaves alphabetically too
+                childAdapter.update(slaves.size(), 0, slaves);
+                mChildAdapters.add(childAdapter);
+            }
         }
 
         notifyDataSetChanged();

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Player.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Player.java
@@ -38,7 +38,7 @@ import uk.org.ngo.squeezer.Util;
 import uk.org.ngo.squeezer.framework.Item;
 
 
-public class Player extends Item {
+public class Player extends Item implements Comparable {
 
     private String mName;
 
@@ -58,6 +58,11 @@ public class Player extends Item {
 
     /** Is the player connected? */
     private boolean mConnected;
+
+    @Override
+    public int compareTo(Object otherPlayer) {
+        return this.mName.compareTo(((Player)otherPlayer).mName);
+    }
 
     public static class Pref {
         /** The types of player preferences. */


### PR DESCRIPTION
Some people on the slimdevices forum wondered if the player list can be
ordered alphabetically in Squeezer. I had noticed too that the player
list looked random (I now know it was ordered on mac-address).
I have some experience with java / Android, so I gave it a try. I got it
working.
The list in de player select dropdown list is now ordered and the list
in the settings player page is now ordered too (first on sync group, and
then the children within the group).
In my opinion, Squeezer is the best LMS controller app. I would be
honored if this change was included in a new Squeezer release.