### PR TITLE
doclint disable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,6 @@
+allprojects {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+        options.addStringOption('encoding', 'UTF-8')
+    }
+}


### PR DESCRIPTION
- Made application movable to SD card
- Turned of doclint (JDK 8) since it caused errors in the eventbus code comments