### PR TITLE
Fix gradle 2.2.3 compilability

### DIFF
--- a/libs/datetimepicker/build.gradle
+++ b/libs/datetimepicker/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'


### PR DESCRIPTION
Added jcenter repository to lib datetimepicker as already existing in Squeezer - maven repository does not contain gradle 2.2.3 yet