### PR TITLE
Re-enable next button when streaming

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
@@ -656,7 +656,7 @@ public class NowPlayingFragment extends Fragment implements View.OnCreateContext
                 // TODO: figure out how to parse the buttons HASH;
                 // for now just assume the next button is enabled if there was a
                 // "buttons" response.
-                setButtonState(nextButton, song.getButtons().length() == 0);
+                setButtonState(nextButton, song.getButtons().length() != 0);
                 disableButton(prevButton);
                 if (btnContextMenu != null) {
                     btnContextMenu.setVisibility(View.GONE);


### PR DESCRIPTION
Logic introduced in 946412daea73842878736d311ac85668a4ca9001 was backwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nikclayton/android-squeezer/336)
<!-- Reviewable:end -->
